### PR TITLE
Allow choosing widget profiles and delete profiles

### DIFF
--- a/DailyQuotes/ConfigurationAppIntent.swift
+++ b/DailyQuotes/ConfigurationAppIntent.swift
@@ -4,6 +4,6 @@ import WidgetKit
 struct ConfigurationAppIntent: WidgetConfigurationIntent {
     static var title: LocalizedStringResource = "הגדר את הווידג'ט"
 
-    @Parameter(title: "בחר ציטוט")
-    var selectedQuote: QuoteOption?
+    @Parameter(title: "בחר פרופיל")
+    var profile: NewProfileEntity?
 }

--- a/DailyQuotes/ProfileListView.swift
+++ b/DailyQuotes/ProfileListView.swift
@@ -23,8 +23,13 @@ struct ProfileListView: View {
             }
             .navigationTitle("Profiles")
             .toolbar {
-                Button(action: { showEditor = true }) {
-                    Image(systemName: "plus")
+                ToolbarItem(placement: .navigationBarLeading) {
+                    EditButton()
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { showEditor = true }) {
+                        Image(systemName: "plus")
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Use profile selector in widget configuration so editing a widget lists profiles instead of quotes
- Add edit button to profile list to enable removing profiles

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_b_68937c920ce0832b8bf9a862aadc7c24