### PR TITLE
Expand profile customization

### DIFF
--- a/DailyQuotes/ProfileListView.swift
+++ b/DailyQuotes/ProfileListView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct ProfileListView: View {
     @State private var profiles: [NewWidgetProfile] = NewProfileManager.load()
     @State private var showEditor = false
+    @State private var editingProfile: NewWidgetProfile?
+    @Environment(\.editMode) private var editMode
 
     var body: some View {
         NavigationView {
@@ -10,10 +12,16 @@ struct ProfileListView: View {
                 ForEach(profiles) { profile in
                     HStack {
                         Circle()
-                            .fill(profile.color.color)
+                            .fill(profile.textColor.color)
                             .frame(width: 20, height: 20)
                         Text(profile.name)
-                            .font(.system(size: CGFloat(profile.textSize)))
+                            .font(.system(size: profile.textSize.size))
+                    }
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        if editMode?.wrappedValue == .active {
+                            editingProfile = profile
+                        }
                     }
                 }
                 .onDelete { indexSet in
@@ -39,35 +47,71 @@ struct ProfileListView: View {
                 NewProfileManager.save(profiles)
             }
         }
+        .sheet(item: $editingProfile) { profile in
+            ProfileEditorView(profile: profile) { updated in
+                if let index = profiles.firstIndex(where: { $0.id == updated.id }) {
+                    profiles[index] = updated
+                    NewProfileManager.save(profiles)
+                }
+            }
+        }
     }
 }
 
 struct ProfileEditorView: View {
     @Environment(\.dismiss) private var dismiss
-    @State private var name: String = ""
-    @State private var color: Color = .primary
-    @State private var textSize: Double = 16
+    @State private var name: String
+    @State private var textColor: Color
+    @State private var backgroundColor: Color
+    @State private var textSize: NewWidgetProfile.TextSize
+    @State private var rotation: Int
+    private let isEditing: Bool
 
     var onSave: (NewWidgetProfile) -> Void
+
+    init(profile: NewWidgetProfile? = nil, onSave: @escaping (NewWidgetProfile) -> Void) {
+        self.onSave = onSave
+        self.isEditing = profile != nil
+        _name = State(initialValue: profile?.name ?? "")
+        _textColor = State(initialValue: profile?.textColor.color ?? .primary)
+        _backgroundColor = State(initialValue: profile?.backgroundColor.color ?? .white)
+        _textSize = State(initialValue: profile?.textSize ?? .medium)
+        _rotation = State(initialValue: profile?.rotation ?? 1)
+    }
 
     var body: some View {
         NavigationView {
             Form {
                 TextField("Name", text: $name)
-                ColorPicker("Color", selection: $color)
-                VStack(alignment: .leading) {
-                    Text("Text Size: \(Int(textSize))")
-                    Slider(value: $textSize, in: 10...40)
+                ColorPicker("Text Color", selection: $textColor)
+                ColorPicker("Background Color", selection: $backgroundColor)
+                Picker("Text Size", selection: $textSize) {
+                    ForEach(NewWidgetProfile.TextSize.allCases, id: \.self) { size in
+                        Text(size.rawValue.capitalized).tag(size)
+                    }
+                }
+                .pickerStyle(.segmented)
+                HStack {
+                    Text("Rotation")
+                    Spacer()
+                    Button(action: { if rotation > 0 { rotation -= 1 } }) {
+                        Image(systemName: "minus.circle")
+                    }
+                    Text("\(rotation)")
+                        .frame(minWidth: 30)
+                    Button(action: { rotation += 1 }) {
+                        Image(systemName: "plus.circle")
+                    }
                 }
             }
-            .navigationTitle("New Profile")
+            .navigationTitle(isEditing ? "Edit Profile" : "New Profile")
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") {
-                        let profile = NewWidgetProfile(name: name, color: CodableColor(color), textSize: textSize)
+                        let profile = NewWidgetProfile(name: name, textColor: CodableColor(textColor), backgroundColor: CodableColor(backgroundColor), textSize: textSize, rotation: rotation)
                         onSave(profile)
                         dismiss()
                     }

--- a/NewProfileEntity.swift
+++ b/NewProfileEntity.swift
@@ -15,18 +15,22 @@ struct NewProfileEntity: AppEntity, Identifiable {
 
     let id: UUID
     let name: String
-    let color: CodableColor
-    let textSize: Double
+    let textColor: CodableColor
+    let backgroundColor: CodableColor
+    let textSize: NewWidgetProfile.TextSize
+    let rotation: Int
 
     init(profile: NewWidgetProfile) {
         self.id = profile.id
         self.name = profile.name
-        self.color = profile.color
+        self.textColor = profile.textColor
+        self.backgroundColor = profile.backgroundColor
         self.textSize = profile.textSize
+        self.rotation = profile.rotation
     }
 
     var profile: NewWidgetProfile {
-        NewWidgetProfile(id: id, name: name, color: color, textSize: textSize)
+        NewWidgetProfile(id: id, name: name, textColor: textColor, backgroundColor: backgroundColor, textSize: textSize, rotation: rotation)
     }
 
     var displayRepresentation: DisplayRepresentation {

--- a/NewWidgetProfile.swift
+++ b/NewWidgetProfile.swift
@@ -23,8 +23,24 @@ struct CodableColor: Codable, Hashable {
 }
 
 struct NewWidgetProfile: Identifiable, Codable, Hashable {
+    enum TextSize: String, Codable, CaseIterable, Hashable {
+        case small
+        case medium
+        case large
+
+        var size: CGFloat {
+            switch self {
+            case .small: return 14
+            case .medium: return 18
+            case .large: return 24
+            }
+        }
+    }
+
     var id: UUID = UUID()
     var name: String
-    var color: CodableColor
-    var textSize: Double
+    var textColor: CodableColor
+    var backgroundColor: CodableColor
+    var textSize: TextSize
+    var rotation: Int
 }


### PR DESCRIPTION
## Summary
- Add text and background color options to profiles
- Replace text size slider with small/medium/large selector
- Introduce rotation field and ability to edit profiles
- Update widget timeline to honor rotation frequency

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_689b1b7508f0832b88166c1217be618a