### PR TITLE
Enable profile editing and custom gallery selection

### DIFF
--- a/DailyQuotesWidget/DailyQuotesWidget.swift
+++ b/DailyQuotesWidget/DailyQuotesWidget.swift
@@ -9,18 +9,18 @@ struct SimpleEntry: TimelineEntry {
 
 struct Provider: AppIntentTimelineProvider {
     func placeholder(in context: Context) -> SimpleEntry {
-        let sample = NewWidgetProfile(name: "דוגמה", textColor: CodableColor(.primary), backgroundColor: CodableColor(.white), backgroundImages: ["Photo1", "Photo2", "Photo3"], textSize: .medium, rotation: 1)
+        let sample = NewWidgetProfile(name: "דוגמה", textColor: CodableColor(.primary), backgroundColor: CodableColor(.white), backgroundImages: nil, textSize: .medium, rotation: 1)
         return SimpleEntry(date: .now, verse: "פסוק לדוגמה", profile: sample)
     }
 
     func snapshot(for configuration: ConfigurationAppIntent, in context: Context) async -> SimpleEntry {
         let verse = await NewTehillimService.fetchRandomVerse()
-        let profile = configuration.profile?.profile ?? NewWidgetProfile(name: "ברירת מחדל", textColor: CodableColor(.primary), backgroundColor: CodableColor(.white), backgroundImages: ["Photo1", "Photo2", "Photo3"], textSize: .medium, rotation: 1)
+        let profile = configuration.profile?.profile ?? NewWidgetProfile(name: "ברירת מחדל", textColor: CodableColor(.primary), backgroundColor: CodableColor(.white), backgroundImages: nil, textSize: .medium, rotation: 1)
         return SimpleEntry(date: .now, verse: verse, profile: profile)
     }
 
     func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<SimpleEntry> {
-        let profile = configuration.profile?.profile ?? NewWidgetProfile(name: "ברירת מחדל", textColor: CodableColor(.primary), backgroundColor: CodableColor(.white), backgroundImages: ["Photo1", "Photo2", "Photo3"], textSize: .medium, rotation: 1)
+        let profile = configuration.profile?.profile ?? NewWidgetProfile(name: "ברירת מחדל", textColor: CodableColor(.primary), backgroundColor: CodableColor(.white), backgroundImages: nil, textSize: .medium, rotation: 1)
         let rotations = max(profile.rotation, 1)
         let interval: TimeInterval = 86400 / Double(rotations)
         var entries: [SimpleEntry] = []


### PR DESCRIPTION
## Summary
- allow tapping profiles to edit them
- let users pick from scrollable gallery images in profile editor
- remove hard-coded gallery images to prevent missing asset placeholders

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_689b359d2150832b87ab05c0794d4de7