### PR TITLE
Simplify widget to load shared background image

### DIFF
--- a/DailyQuotesWidget/DailyQuotesWidget.swift
+++ b/DailyQuotesWidget/DailyQuotesWidget.swift
@@ -1,97 +1,16 @@
 import WidgetKit
 import SwiftUI
-import UIKit
-
-struct SimpleEntry: TimelineEntry {
-    let date: Date
-    let verse: String
-    let profile: NewWidgetProfile
-}
-
-struct Provider: AppIntentTimelineProvider {
-    func placeholder(in context: Context) -> SimpleEntry {
-        let sample = NewWidgetProfile(name: "דוגמה", textColor: CodableColor(.primary), backgroundColor: CodableColor(.white), backgroundImages: nil, textSize: .medium, rotation: 1)
-        return SimpleEntry(date: .now, verse: "פסוק לדוגמה", profile: sample)
-    }
-
-    func snapshot(for configuration: ConfigurationAppIntent, in context: Context) async -> SimpleEntry {
-        let verse = await NewTehillimService.fetchRandomVerse()
-        let profile = configuration.profile?.profile ?? NewWidgetProfile(name: "ברירת מחדל", textColor: CodableColor(.primary), backgroundColor: CodableColor(.white), backgroundImages: nil, textSize: .medium, rotation: 1)
-        return SimpleEntry(date: .now, verse: verse, profile: profile)
-    }
-
-    func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<SimpleEntry> {
-        let profile = configuration.profile?.profile ?? NewWidgetProfile(name: "ברירת מחדל", textColor: CodableColor(.primary), backgroundColor: CodableColor(.white), backgroundImages: nil, textSize: .medium, rotation: 1)
-        let rotations = max(profile.rotation, 1)
-        let interval: TimeInterval = 86400 / Double(rotations)
-        var entries: [SimpleEntry] = []
-        let currentDate = Date()
-
-        for i in 0..<rotations {
-            let verse = await NewTehillimService.fetchRandomVerse()
-            let entryDate = currentDate.addingTimeInterval(Double(i) * interval)
-            entries.append(SimpleEntry(date: entryDate, verse: verse, profile: profile))
-        }
-
-        return Timeline(entries: entries, policy: .atEnd)
-    }
-}
-
-struct DailyQuotesWidgetEntryView: View {
-    var entry: Provider.Entry
-
-    private func image(named name: String) -> Image? {
-        let appBundleURL = Bundle.main.bundleURL
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        if let bundle = Bundle(url: appBundleURL),
-           let uiImage = UIImage(named: name, in: bundle, with: nil) {
-            return Image(uiImage: uiImage)
-        }
-        return nil
-    }
-
-var body: some View {
-         ZStack {
-            if let images = entry.profile.backgroundImages, !images.isEmpty {
-                TabView {
-                    ForEach(images, id: \.self) { name in
-                        if let img = image(named: name) {
-                            img
-                                .resizable()
-                                .scaledToFill()
-                                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                .clipped()
-                        } else {
-                            entry.profile.backgroundColor.color
-                        }
-                    }
-                }
-                .tabViewStyle(PageTabViewStyle())
-            } else {
-                entry.profile.backgroundColor.color
-            }
-            VStack(alignment: .leading, spacing: 6) {
-                Text(entry.verse)
-                    .font(.system(size: entry.profile.textSize.size))
-                    .foregroundColor(entry.profile.textColor.color)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            .padding()
-        }
-        .containerBackground(.clear, for: .widget)
-    }
-}
 
 struct DailyQuotesWidget: Widget {
     let kind: String = "DailyQuotesWidget"
 
     var body: some WidgetConfiguration {
-        AppIntentConfiguration(kind: kind, intent: ConfigurationAppIntent.self, provider: Provider()) { entry in
-            DailyQuotesWidgetEntryView(entry: entry)
+        StaticConfiguration(kind: kind, provider: Provider()) { entry in
+            DailyQuotesWidgetView(entry: entry)
         }
-        .configurationDisplayName("פסוק יומי")
-        .description("הצג פסוק מתהילים לפי פרופיל")
-        .supportedFamilies([.systemSmall, .systemMedium])
+        .configurationDisplayName("Daily Quotes")
+        .description("Shows a background image from the app group container.")
+        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
     }
 }
+

--- a/DailyQuotesWidget/Provider.swift
+++ b/DailyQuotesWidget/Provider.swift
@@ -1,23 +1,23 @@
 import WidgetKit
 import SwiftUI
 
-struct Entry: TimelineEntry {
+struct BackgroundEntry: TimelineEntry {
     let date: Date
     let backgroundURL: URL?
 }
 
 struct Provider: TimelineProvider {
-    func placeholder(in context: Context) -> Entry {
-        Entry(date: Date(), backgroundURL: loadBackgroundURL())
+    func placeholder(in context: Context) -> BackgroundEntry {
+        BackgroundEntry(date: Date(), backgroundURL: loadBackgroundURL())
     }
 
-    func getSnapshot(in context: Context, completion: @escaping (Entry) -> ()) {
-        let entry = Entry(date: Date(), backgroundURL: loadBackgroundURL())
+    func getSnapshot(in context: Context, completion: @escaping (BackgroundEntry) -> ()) {
+        let entry = BackgroundEntry(date: Date(), backgroundURL: loadBackgroundURL())
         completion(entry)
     }
 
-    func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
-        let entry = Entry(date: Date(), backgroundURL: loadBackgroundURL())
+    func getTimeline(in context: Context, completion: @escaping (Timeline<BackgroundEntry>) -> ()) {
+        let entry = BackgroundEntry(date: Date(), backgroundURL: loadBackgroundURL())
         let timeline = Timeline(entries: [entry], policy: .never)
         completion(timeline)
     }
@@ -30,5 +30,12 @@ struct Provider: TimelineProvider {
         }
         print("Provider: using background at", url.path)
         return url
+    }
+
+    private func sharedBackgroundURL() -> URL? {
+        let groupID = "group.com.liadaltif.DailyQuotes"
+        return FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: groupID)?
+            .appendingPathComponent("background.jpg")
     }
 }

--- a/DailyQuotesWidget/WidgetView.swift
+++ b/DailyQuotesWidget/WidgetView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import WidgetKit
 
-struct MyWidgetView: View {
+struct DailyQuotesWidgetView: View {
     var entry: BackgroundEntry
 
     var body: some View {
@@ -24,18 +24,5 @@ struct MyWidgetView: View {
                 Color.black.opacity(0.2)
             }
         }
-    }
-}
-
-@main
-struct MyWidget: Widget {
-    let kind: String = "MyWidget"
-
-    var body: some WidgetConfiguration {
-        StaticConfiguration(kind: kind, provider: Provider()) { entry in
-            MyWidgetView(entry: entry)
-        }
-        .configurationDisplayName("My Widget")
-        .description("Shows a background image from the app group container.")
     }
 }


### PR DESCRIPTION
## Summary
- replace complex widget with simple background image widget
- load shared image from app group container via Provider
- display image in `DailyQuotesWidgetView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_689b4d898a84832bb4f5c2c67004854a