### PR TITLE
Improve widget image handling and profile updates

### DIFF
--- a/DailyQuotes/ProfileListView.swift
+++ b/DailyQuotes/ProfileListView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WidgetKit
 
 @MainActor
 struct ProfileListView: View {
@@ -25,6 +26,7 @@ struct ProfileListView: View {
                 .onDelete { indexSet in
                     profiles.remove(atOffsets: indexSet)
                     NewProfileManager.save(profiles)
+                    WidgetCenter.shared.reloadAllTimelines()
                 }
             }
             .navigationTitle("Profiles")
@@ -43,6 +45,7 @@ struct ProfileListView: View {
             ProfileEditorView { profile in
                 profiles.append(profile)
                 NewProfileManager.save(profiles)
+                WidgetCenter.shared.reloadAllTimelines()
             }
         }
         .sheet(item: $editingProfile) { profile in
@@ -50,6 +53,7 @@ struct ProfileListView: View {
                 if let index = profiles.firstIndex(where: { $0.id == updated.id }) {
                     profiles[index] = updated
                     NewProfileManager.save(profiles)
+                    WidgetCenter.shared.reloadAllTimelines()
                 }
             }
         }

--- a/DailyQuotesWidget/Provider.swift
+++ b/DailyQuotesWidget/Provider.swift
@@ -23,7 +23,7 @@ struct Provider: AppIntentTimelineProvider {
 
     func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<BackgroundEntry> {
         let profile = configuration.profile?.profile
-        let backgroundURL = loadBackgroundURL()
+        let backgroundURL = (profile?.backgroundImages == nil) ? loadBackgroundURL() : nil
         var quote = WidgetSharedData.load()
         if quote == nil {
             print("Provider: no saved quote found, fetching random Tehillim verse")
@@ -40,7 +40,7 @@ struct Provider: AppIntentTimelineProvider {
         let profile = configuration.profile?.profile
         let quote = WidgetSharedData.load() ?? "Add a quote in the app"
         return BackgroundEntry(date: Date(),
-                               backgroundURL: loadBackgroundURL(),
+                               backgroundURL: (profile?.backgroundImages == nil) ? loadBackgroundURL() : nil,
                                quote: quote,
                                profile: profile)
     }

--- a/DailyQuotesWidget/WidgetView.swift
+++ b/DailyQuotesWidget/WidgetView.swift
@@ -6,14 +6,23 @@ struct DailyQuotesWidgetView: View {
 
     var body: some View {
         ZStack {
-            if let url = entry.backgroundURL,
-               let uiImage = UIImage(contentsOfFile: url.path) {
-               Image(uiImage: uiImage)
+            if let names = entry.profile?.backgroundImages,
+               let random = names.randomElement() {
+                Image(random)
                     .resizable()
-                    .scaledToFill()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .clipped()
+            } else if let url = entry.backgroundURL,
+                      let uiImage = UIImage(contentsOfFile: url.path) {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .clipped()
             } else {
                 (entry.profile?.backgroundColor.color ?? Color.black.opacity(0.2))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
 
             Text(entry.quote)
@@ -21,7 +30,9 @@ struct DailyQuotesWidgetView: View {
                 .foregroundColor(entry.profile?.textColor.color ?? .white)
                 .multilineTextAlignment(.center)
                 .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.clear)
         .ignoresSafeArea()
         .applyWidgetBackground()


### PR DESCRIPTION
## Summary
- Ensure widget fills its container and display profile images or custom photos without black bezels
- Reload widget timelines when profiles are added, edited, or removed
- Skip unnecessary file lookups when a profile supplies built-in gallery images

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_b_689b5cfee624832b8a83d5deb8a998b2