### PR TITLE
Revamp widget profile editor

### DIFF
--- a/DailyQuotesWidget/Provider.swift
+++ b/DailyQuotesWidget/Provider.swift
@@ -23,7 +23,7 @@ struct Provider: AppIntentTimelineProvider {
 
     func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<BackgroundEntry> {
         let profile = configuration.profile?.profile
-        let backgroundURL = (profile?.backgroundImages == nil) ? loadBackgroundURL() : nil
+        let backgroundURL = (profile?.backgroundImage == nil) ? loadBackgroundURL() : nil
         var quote = WidgetSharedData.load()
         if quote == nil {
             print("Provider: no saved quote found, fetching random Tehillim verse")
@@ -40,7 +40,7 @@ struct Provider: AppIntentTimelineProvider {
         let profile = configuration.profile?.profile
         let quote = WidgetSharedData.load() ?? "Add a quote in the app"
         return BackgroundEntry(date: Date(),
-                               backgroundURL: (profile?.backgroundImages == nil) ? loadBackgroundURL() : nil,
+                               backgroundURL: (profile?.backgroundImage == nil) ? loadBackgroundURL() : nil,
                                quote: quote,
                                profile: profile)
     }

--- a/DailyQuotesWidget/WidgetView.swift
+++ b/DailyQuotesWidget/WidgetView.swift
@@ -6,9 +6,8 @@ struct DailyQuotesWidgetView: View {
 
     var body: some View {
         ZStack {
-            if let names = entry.profile?.backgroundImages,
-               let random = names.randomElement() {
-                Image(random)
+            if let name = entry.profile?.backgroundImage {
+                Image(name)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -21,13 +20,12 @@ struct DailyQuotesWidgetView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .clipped()
             } else {
-                (entry.profile?.backgroundColor.color ?? Color.black.opacity(0.2))
+                (entry.profile?.isDarkMode ?? false ? Color.black : Color.white)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
 
             Text(entry.quote)
-                .font(.system(size: entry.profile?.textSize.size ?? 16))
-                .foregroundColor(entry.profile?.textColor.color ?? .white)
+                .foregroundColor(entry.profile?.isDarkMode ?? false ? .white : .black)
                 .multilineTextAlignment(.center)
                 .padding()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/NewProfileEntity.swift
+++ b/NewProfileEntity.swift
@@ -7,7 +7,6 @@
 
 
 import AppIntents
-import SwiftUI
 
 struct NewProfileEntity: AppEntity, Identifiable {
     static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Profile")
@@ -15,24 +14,20 @@ struct NewProfileEntity: AppEntity, Identifiable {
 
     let id: UUID
     let name: String
-    let textColor: CodableColor
-    let backgroundColor: CodableColor
-    let backgroundImages: [String]?
-    let textSize: NewWidgetProfile.TextSize
-    let rotation: Int
+    let backgroundImage: String?
+    let isDarkMode: Bool
+    let versesPerDay: Int
 
     init(profile: NewWidgetProfile) {
         self.id = profile.id
         self.name = profile.name
-        self.textColor = profile.textColor
-        self.backgroundColor = profile.backgroundColor
-        self.backgroundImages = profile.backgroundImages
-        self.textSize = profile.textSize
-        self.rotation = profile.rotation
+        self.backgroundImage = profile.backgroundImage
+        self.isDarkMode = profile.isDarkMode
+        self.versesPerDay = profile.versesPerDay
     }
 
     var profile: NewWidgetProfile {
-        NewWidgetProfile(id: id, name: name, textColor: textColor, backgroundColor: backgroundColor, backgroundImages: backgroundImages, textSize: textSize, rotation: rotation)
+        NewWidgetProfile(id: id, name: name, backgroundImage: backgroundImage, isDarkMode: isDarkMode, versesPerDay: versesPerDay)
     }
 
     var displayRepresentation: DisplayRepresentation {

--- a/NewWidgetProfile.swift
+++ b/NewWidgetProfile.swift
@@ -1,47 +1,7 @@
-import SwiftUI
-import UIKit
-
-struct CodableColor: Codable, Hashable {
-    var red: Double
-    var green: Double
-    var blue: Double
-    var opacity: Double
-
-    init(_ color: Color) {
-        let ui = UIColor(color)
-        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
-        ui.getRed(&r, green: &g, blue: &b, alpha: &a)
-        self.red = Double(r)
-        self.green = Double(g)
-        self.blue = Double(b)
-        self.opacity = Double(a)
-    }
-
-    var color: Color {
-        Color(red: red, green: green, blue: blue, opacity: opacity)
-    }
-}
-
 struct NewWidgetProfile: Identifiable, Codable, Hashable {
-    enum TextSize: String, Codable, CaseIterable, Hashable {
-        case small
-        case medium
-        case large
-
-        var size: CGFloat {
-            switch self {
-            case .small: return 14
-            case .medium: return 18
-            case .large: return 24
-            }
-        }
-    }
-
     var id: UUID = UUID()
     var name: String
-    var textColor: CodableColor
-    var backgroundColor: CodableColor
-    var backgroundImages: [String]?
-    var textSize: TextSize
-    var rotation: Int
+    var backgroundImage: String?
+    var isDarkMode: Bool
+    var versesPerDay: Int
 }


### PR DESCRIPTION
## Summary
- simplify widget profile to a single background image, dark/light theme, and verse count
- redesign profile editor with Hebrew text and right-to-left layout
- update widget rendering and provider for new profile fields

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_689b60248c7c832b9ce2fffcf090fa07